### PR TITLE
fix: Исправление неактивной кнопки на стартовом экране

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,7 @@ html {
     height: 100%;
     overflow: hidden;
     z-index: 1;
+    pointer-events: none; /* Allow clicks to pass through */
 }
 .bird {
     position: absolute;


### PR DESCRIPTION
Этот коммит исправляет критическую ошибку, из-за которой кнопка на стартовом экране была некликабельной.

Контейнер с анимацией летящих птиц (`.birds-container`) перехватывал клики мыши, не давая им достичь кнопки.

Исправление добавляет свойство `pointer-events: none;` к классу `.birds-container` в `styles.css`. Это делает слой с анимацией "невидимым" для кликов, позволяя им "проходить сквозь" него к кнопке.