### PR TITLE
feat: Add animated photo section

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,18 @@
             <p class="story-text text-with-bg">Разделяя одну мечту на двоих, мы решили соединить наши сердца. Мы будем рады видеть вас на нашем празднике любви.</p>
         </section>
 
+        <section class="new-story-section">
+            <h3 class="section-title" data-animated>иногда и мы можем дать жару</h3>
+            <div class="new-gallery-container">
+                <div class="new-gallery-item">
+                    <img src="new1.jpg" alt="New Story 1">
+                </div>
+                <div class="new-gallery-item">
+                    <img src="new2.jpg" alt="New Story 2">
+                </div>
+            </div>
+        </section>
+
         <div class="section-divider"></div>
 
         <section class="program-section">

--- a/styles.css
+++ b/styles.css
@@ -706,6 +706,71 @@ main > section.visible, .site-footer.visible {
         margin-right: 1rem;
     }
 
+.new-story-section {
+    padding: 5rem 1.5rem;
+    text-align: center;
+    overflow: hidden;
+}
+
+.new-gallery-container {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.new-gallery-item {
+    position: relative;
+    overflow: hidden;
+    border-radius: 12px;
+    box-shadow: 0 8px 25px rgba(0,0,0,0.08);
+    transition: box-shadow 0.4s ease, transform 0.4s ease;
+    opacity: 0; /* Start hidden for animation */
+}
+
+.new-story-section.visible .new-gallery-item:nth-child(1) {
+    animation: slideInFromLeft 1s forwards;
+}
+
+.new-story-section.visible .new-gallery-item:nth-child(2) {
+    animation: slideInFromRight 1s forwards;
+}
+
+.new-gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.new-gallery-item:hover {
+    transform: scale(1.05);
+    box-shadow: 0 15px 30px rgba(0,0,0,0.15);
+}
+
+@keyframes slideInFromLeft {
+    from {
+        transform: translateX(-100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideInFromRight {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
 
     .timeline {
         border-left: 2px solid var(--accent-gold);
@@ -734,6 +799,11 @@ main > section.visible, .site-footer.visible {
     }
     .color-palette {
         justify-content: center; /* Center the swatches */
+    }
+
+    .new-gallery-container {
+        flex-direction: column;
+        align-items: center;
     }
 }
 


### PR DESCRIPTION
Adds a new photo section after the existing gallery with a title and two new images.

The new images are animated to slide in from the left and right sides of the screen when the section is scrolled into view.

The section is also responsive, stacking the images on mobile devices for a better user experience.